### PR TITLE
Fix: bug when removing members

### DIFF
--- a/src/mappings/BaseERC20Guild/mapping.ts
+++ b/src/mappings/BaseERC20Guild/mapping.ts
@@ -1,4 +1,10 @@
-import { ipfs, json, JSONValueKind, BigInt } from '@graphprotocol/graph-ts';
+import {
+  ipfs,
+  json,
+  JSONValueKind,
+  BigInt,
+  store,
+} from '@graphprotocol/graph-ts';
 import {
   Guild,
   Proposal,
@@ -285,9 +291,10 @@ export function handleTokenWithdrawal(event: TokensWithdrawn): void {
     guild.members = guildMembersClone;
 
     guild.save();
+    store.remove('Member', memberId);
+  } else {
+    member!.save();
   }
-
-  member!.unset(memberId);
 }
 
 function isIPFS(contentHash: string): boolean {

--- a/src/mappings/ERC20SnapshotRep/mapping.ts
+++ b/src/mappings/ERC20SnapshotRep/mapping.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, log } from '@graphprotocol/graph-ts';
+import { Address, BigInt, log, store } from '@graphprotocol/graph-ts';
 import { Guild, Member, Token } from '../../types/schema';
 import {
   ERC20SnapshotRep,
@@ -55,7 +55,7 @@ export function handleTransfer(event: Transfer): void {
     guild.members = guildMembersClone;
 
     guild.save();
-    member.unset(memberId);
+    store.remove('Member', memberId);
   }
 }
 


### PR DESCRIPTION
When removing members, their entity won't get deleted, just the reference in the guild array. This prevented the same member from showing in the members' list if they withdrew all their tokens and rejoined.

Also enables the possibility that a member withdraws only a partial amount of tokens.